### PR TITLE
refactor: dto가 서비스 내부 로직까지 들어가는 코드 변경 #4

### DIFF
--- a/src/main/java/soongsil/kidbean/server/quiz/domain/ImageQuizSolved.java
+++ b/src/main/java/soongsil/kidbean/server/quiz/domain/ImageQuizSolved.java
@@ -5,11 +5,14 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import soongsil.kidbean.server.member.domain.Member;
 import java.time.LocalDateTime;
 
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImageQuizSolved {
@@ -19,6 +22,7 @@ public class ImageQuizSolved {
     @Column(name = "solved_id")
     private Long solvedId;
 
+    @CreatedDate
     @LastModifiedDate
     private LocalDateTime solvedTime;
 

--- a/src/main/java/soongsil/kidbean/server/quiz/repository/ImageQuizSolvedRepository.java
+++ b/src/main/java/soongsil/kidbean/server/quiz/repository/ImageQuizSolvedRepository.java
@@ -12,7 +12,7 @@ import soongsil.kidbean.server.quiz.domain.ImageQuizSolved;
 @Repository
 public interface ImageQuizSolvedRepository extends JpaRepository<ImageQuizSolved, Long> {
 
-    boolean existsImageQuizSolvedByImageQuiz_QuizIdAndMember(Long quizId, Member member);
+    boolean existsImageQuizSolvedByImageQuizAndMember(ImageQuiz imageQuiz, Member member);
 
     Optional<ImageQuizSolved> findByImageQuizAndMember(ImageQuiz imageQuiz, Member member);
 

--- a/src/test/java/soongsil/kidbean/server/quiz/application/ImageQuizSolvedServiceTest.java
+++ b/src/test/java/soongsil/kidbean/server/quiz/application/ImageQuizSolvedServiceTest.java
@@ -40,8 +40,7 @@ class ImageQuizSolvedServiceTest {
         given(imageQuizRepository.findById(IMAGE_QUIZ_ANIMAL.getQuizId()))
                 .willReturn(Optional.of(IMAGE_QUIZ_ANIMAL));
         //이전에 풀었던 문제
-        given(imageQuizSolvedRepository.existsImageQuizSolvedByImageQuiz_QuizIdAndMember(
-                IMAGE_QUIZ_ANIMAL.getQuizId(), MEMBER))
+        given(imageQuizSolvedRepository.existsImageQuizSolvedByImageQuizAndMember(IMAGE_QUIZ_ANIMAL, MEMBER))
                 .willReturn(true);
         given(imageQuizSolvedRepository.findByImageQuizAndMember(IMAGE_QUIZ_ANIMAL, MEMBER))
                 .willReturn(Optional.of(IMAGE_QUIZ_SOLVED_ANIMAL_TRUE));
@@ -62,8 +61,8 @@ class ImageQuizSolvedServiceTest {
 
         given(imageQuizRepository.findById(IMAGE_QUIZ_ANIMAL.getQuizId()))
                 .willReturn(Optional.of(IMAGE_QUIZ_ANIMAL));
-        given(imageQuizSolvedRepository.existsImageQuizSolvedByImageQuiz_QuizIdAndMember(
-                IMAGE_QUIZ_ANIMAL.getQuizId(), MEMBER)).willReturn(true);
+        given(imageQuizSolvedRepository.existsImageQuizSolvedByImageQuizAndMember(IMAGE_QUIZ_ANIMAL, MEMBER))
+                .willReturn(true);
         given(imageQuizSolvedRepository.findByImageQuizAndMember(IMAGE_QUIZ_ANIMAL, MEMBER))
                 .willReturn(Optional.of(IMAGE_QUIZ_SOLVED_ANIMAL_FALSE));
 
@@ -83,8 +82,7 @@ class ImageQuizSolvedServiceTest {
 
         given(imageQuizRepository.findById(IMAGE_QUIZ_ANIMAL.getQuizId()))
                 .willReturn(Optional.of(IMAGE_QUIZ_ANIMAL));
-        given(imageQuizSolvedRepository.existsImageQuizSolvedByImageQuiz_QuizIdAndMember(
-                IMAGE_QUIZ_ANIMAL.getQuizId(), MEMBER))
+        given(imageQuizSolvedRepository.existsImageQuizSolvedByImageQuizAndMember(IMAGE_QUIZ_ANIMAL, MEMBER))
                 .willReturn(false);
 
         //when


### PR DESCRIPTION
## 관련 이슈

- Resolves #4 

## 개요

> dto가 서비스 내부 로직까지 들어가는 코드 변경

## 작업 사항

- dto가 서비스 내부 로직까지 들어가는 코드 변경
- erd에 시간이 들어가지 않는 버그 수정

## Check List
- [ ] PR 제목을 커밋 규칙에 맞게 작성
- [ ] PR에 해당되는 Issue를 연결 완료
- [ ] 작업한 사람 모두를 Assign
- [ ] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [ ] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
