### PR TITLE
feat: 마이페이지 문제 세부 내역 반환 API 구현

### DIFF
--- a/src/main/java/soongsil/kidbean/server/mypage/application/QuizSolvedService.java
+++ b/src/main/java/soongsil/kidbean/server/mypage/application/QuizSolvedService.java
@@ -1,6 +1,7 @@
 package soongsil.kidbean.server.mypage.application;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -10,9 +11,14 @@ import soongsil.kidbean.server.member.repository.MemberRepository;
 import soongsil.kidbean.server.mypage.dto.response.SolvedImageDetailResponse;
 import soongsil.kidbean.server.mypage.dto.response.SolvedImageInfo;
 import soongsil.kidbean.server.mypage.dto.response.SolvedImageListResponse;
+import soongsil.kidbean.server.mypage.dto.response.SolvedSentenceDetailResponse;
 import soongsil.kidbean.server.mypage.dto.response.SolvedRecordInfo;
 import soongsil.kidbean.server.mypage.dto.response.SolvedRecordListResponse;
+import soongsil.kidbean.server.mypage.dto.response.SolvedVoiceDetailResponse;
+import soongsil.kidbean.server.quiz.domain.Analysis;
 import soongsil.kidbean.server.quiz.domain.ImageQuizSolved;
+import soongsil.kidbean.server.quiz.domain.RecordQuizSolved;
+import soongsil.kidbean.server.quiz.repository.AnalysisRepository;
 import soongsil.kidbean.server.quiz.repository.ImageQuizSolvedRepository;
 import soongsil.kidbean.server.quiz.repository.RecordQuizSolvedRepository;
 
@@ -25,6 +31,7 @@ public class QuizSolvedService {
     private final ImageQuizSolvedRepository imageQuizSolvedRepository;
     private final RecordQuizSolvedRepository recordQuizSolvedRepository;
     private final MemberRepository memberRepository;
+    private final AnalysisRepository analysisRepository;
 
     /**
      * @param memberId 멤버Id
@@ -57,25 +64,48 @@ public class QuizSolvedService {
     public SolvedRecordListResponse findSolvedSentence(Long memberId) {
         Member member = findMemberById(memberId);
 
-        List<SolvedRecordInfo> solvedSentenceInfoList = recordQuizSolvedRepository.findAllByMemberAndSentenceQuizIsNotNull(member).stream()
+        List<SolvedRecordInfo> solvedSentenceInfoList = recordQuizSolvedRepository.findAllByMemberAndSentenceQuizIsNotNull(
+                        member).stream()
                 .map(SolvedRecordInfo::from)
                 .toList();
 
         return SolvedRecordListResponse.from(solvedSentenceInfoList);
+    }
+
+    public SolvedSentenceDetailResponse solvedSentenceDetail(Long solvedId) {
+        RecordQuizSolved recordQuizSolved = findRecordQuizSolvedById(solvedId);
+        Optional<Analysis> optionalAnalysis = analysisRepository.findByRecordQuizSolved(recordQuizSolved);
+
+        return optionalAnalysis.map(analysis -> SolvedSentenceDetailResponse.of(recordQuizSolved, analysis))
+                .orElseGet(() -> SolvedSentenceDetailResponse.of(recordQuizSolved, null));
     }
 
     public SolvedRecordListResponse findSolvedVoice(Long memberId) {
         Member member = findMemberById(memberId);
 
-        List<SolvedRecordInfo> solvedSentenceInfoList = recordQuizSolvedRepository.findAllByMemberAndAnswerQuizIsNotNull(member).stream()
+        List<SolvedRecordInfo> solvedSentenceInfoList = recordQuizSolvedRepository.findAllByMemberAndAnswerQuizIsNotNull(
+                        member).stream()
                 .map(SolvedRecordInfo::from)
                 .toList();
 
         return SolvedRecordListResponse.from(solvedSentenceInfoList);
     }
 
+    public SolvedVoiceDetailResponse solvedVoiceDetail(Long solvedId) {
+        RecordQuizSolved recordQuizSolved = findRecordQuizSolvedById(solvedId);
+        Optional<Analysis> optionalAnalysis = analysisRepository.findByRecordQuizSolved(recordQuizSolved);
+
+        return optionalAnalysis.map(analysis -> SolvedVoiceDetailResponse.of(recordQuizSolved, analysis))
+                .orElseGet(() -> SolvedVoiceDetailResponse.of(recordQuizSolved, null));
+    }
+
     private ImageQuizSolved findImageQuizSolvedById(Long solvedId) {
         return imageQuizSolvedRepository.findById(solvedId)
+                .orElseThrow(RuntimeException::new);
+    }
+
+    private RecordQuizSolved findRecordQuizSolvedById(Long recordId) {
+        return recordQuizSolvedRepository.findById(recordId)
                 .orElseThrow(RuntimeException::new);
     }
 

--- a/src/main/java/soongsil/kidbean/server/mypage/dto/response/SolvedImageInfo.java
+++ b/src/main/java/soongsil/kidbean/server/mypage/dto/response/SolvedImageInfo.java
@@ -2,8 +2,10 @@ package soongsil.kidbean.server.mypage.dto.response;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import soongsil.kidbean.server.quiz.domain.ImageQuizSolved;
 
+@Builder
 public record SolvedImageInfo(
         Long solvedId,
         LocalDateTime solvedTime

--- a/src/main/java/soongsil/kidbean/server/mypage/dto/response/SolvedSentenceDetailResponse.java
+++ b/src/main/java/soongsil/kidbean/server/mypage/dto/response/SolvedSentenceDetailResponse.java
@@ -1,0 +1,20 @@
+package soongsil.kidbean.server.mypage.dto.response;
+
+import soongsil.kidbean.server.quiz.domain.Analysis;
+import soongsil.kidbean.server.quiz.domain.RecordQuizSolved;
+
+public record SolvedSentenceDetailResponse(
+        Long solvedId,
+        String question,
+        String kidAnswer,
+        String analysisReport
+) {
+    public static SolvedSentenceDetailResponse of(RecordQuizSolved recordQuizSolved, Analysis analysis) {
+        return new SolvedSentenceDetailResponse(
+                recordQuizSolved.getSolvedId(),
+                recordQuizSolved.getRecordAnswer(),
+                recordQuizSolved.getSentenceAnswer(),
+                analysis.toString() //TODO 수정해야함
+        );
+    }
+}

--- a/src/main/java/soongsil/kidbean/server/mypage/dto/response/SolvedVoiceDetailResponse.java
+++ b/src/main/java/soongsil/kidbean/server/mypage/dto/response/SolvedVoiceDetailResponse.java
@@ -1,0 +1,20 @@
+package soongsil.kidbean.server.mypage.dto.response;
+
+import soongsil.kidbean.server.quiz.domain.Analysis;
+import soongsil.kidbean.server.quiz.domain.RecordQuizSolved;
+
+public record SolvedVoiceDetailResponse(
+        Long solvedId,
+        String question,
+        String kidAnswer,
+        String analysisReport
+) {
+    public static SolvedVoiceDetailResponse of(RecordQuizSolved recordQuizSolved, Analysis analysis) {
+        return new SolvedVoiceDetailResponse(
+                recordQuizSolved.getSolvedId(),
+                recordQuizSolved.getRecordAnswer(),
+                recordQuizSolved.getSentenceAnswer(),
+                analysis.toString() //TODO 수정해야함
+        );
+    }
+}

--- a/src/main/java/soongsil/kidbean/server/mypage/presentation/QuizSolvedController.java
+++ b/src/main/java/soongsil/kidbean/server/mypage/presentation/QuizSolvedController.java
@@ -10,6 +10,8 @@ import soongsil.kidbean.server.mypage.application.QuizSolvedService;
 import soongsil.kidbean.server.mypage.dto.response.SolvedRecordListResponse;
 import soongsil.kidbean.server.mypage.dto.response.SolvedImageDetailResponse;
 import soongsil.kidbean.server.mypage.dto.response.SolvedImageListResponse;
+import soongsil.kidbean.server.mypage.dto.response.SolvedSentenceDetailResponse;
+import soongsil.kidbean.server.mypage.dto.response.SolvedVoiceDetailResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,5 +36,24 @@ public class QuizSolvedController {
     public ResponseEntity<SolvedRecordListResponse> findSolvedSentenceList(
             @PathVariable(name = "memberId") Long memberId) {
         return ResponseEntity.ok(quizSolvedService.findSolvedSentence(memberId));
+    }
+
+    @GetMapping("/sentence/{solvedId}")
+    public ResponseEntity<SolvedSentenceDetailResponse> findSolvedSentenceDetail(
+            @PathVariable(name = "solvedId") Long solvedId) {
+        return ResponseEntity.ok(quizSolvedService.solvedSentenceDetail(solvedId));
+    }
+
+    @GetMapping("/mypage/solved/voice/list/{memberId}")
+    public ResponseEntity<SolvedRecordListResponse> findSolvedVoiceList(
+            @PathVariable(name = "memberId") Long memberId
+    ) {
+        return ResponseEntity.ok(quizSolvedService.findSolvedVoice(memberId));
+    }
+
+    @GetMapping("/voice/{solvedId}")
+    public ResponseEntity<SolvedVoiceDetailResponse> findSolvedVoiceDetail(
+            @PathVariable(name = "solvedId") Long solvedId) {
+        return ResponseEntity.ok(quizSolvedService.solvedVoiceDetail(solvedId));
     }
 }

--- a/src/main/java/soongsil/kidbean/server/quiz/repository/AnalysisRepository.java
+++ b/src/main/java/soongsil/kidbean/server/quiz/repository/AnalysisRepository.java
@@ -1,0 +1,10 @@
+package soongsil.kidbean.server.quiz.repository;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import soongsil.kidbean.server.quiz.domain.Analysis;
+import soongsil.kidbean.server.quiz.domain.RecordQuizSolved;
+
+public interface AnalysisRepository extends JpaRepository<Analysis, Long> {
+    Optional<Analysis> findByRecordQuizSolved(RecordQuizSolved recordQuizSolved);
+}

--- a/src/test/java/soongsil/kidbean/server/mypage/fixture/SolvedImageInfoListFixture.java
+++ b/src/test/java/soongsil/kidbean/server/mypage/fixture/SolvedImageInfoListFixture.java
@@ -1,0 +1,7 @@
+package soongsil.kidbean.server.mypage.fixture;
+
+import java.util.ArrayList;
+import soongsil.kidbean.server.quiz.domain.ImageQuizSolved;
+
+public class SolvedImageInfoListFixture {
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   datasource:
     url: jdbc:h2:tcp://localhost/~/kidbean
     username: sa
-    password:
+    password: test
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,7 +5,7 @@ spring:
   datasource:
     url: jdbc:h2:tcp://localhost/~/kidbean
     username: sa
-    password: test
+    password:
     driver-class-name: org.h2.Driver
   jpa:
     hibernate:


### PR DESCRIPTION
## 관련 이슈

- Resolves #20

## 개요

> 마이페이지 문제 세부 내역 반환 API 구현

## 작업 사항

- 세부 항목 반환 API 

## Check List
- [ ] PR 제목을 커밋 규칙에 맞게 작성
- [ ] PR에 해당되는 Issue를 연결 완료
- [ ] 작업한 사람 모두를 Assign
- [ ] 작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [ ] `main` 브랜치의 최신 상태를 반영하고 있는지 확인
